### PR TITLE
Fix `freerdp` command not found

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,8 @@ services:
     environment:
       DISPLAY_WIDTH: "1600"
       DISPLAY_HEIGHT: "900"
-      RDP_USERNAME: "user"
-      RDP_PASSWORD: "password"
-      RDP_HOST: "192.168.0.2"
+      RDP_USERNAME: ${RDP_USERNAME:-user}
+      RDP_PASSWORD: ${RDP_PASSWORD:-password}
+      RDP_HOST: ${RDP_HOST:-192.168.0.2}
     ports:
       - ${NOVNC_HOST:-127.0.0.1}:${NOVNC_PORT:-8080}:8080

--- a/supervisord/conf.d/xfreerdp.conf
+++ b/supervisord/conf.d/xfreerdp.conf
@@ -1,3 +1,3 @@
 [program:freerdp]
-command = freerdp /u:"%(ENV_RDP_USERNAME)s" /p:"%(ENV_RDP_PASSWORD)s" /v:"%(ENV_RDP_HOST)s":"%(ENV_RDP_PORT)s" %(ENV_RDP_ARGUMENTS)s
+command = xfreerdp /u:"%(ENV_RDP_USERNAME)s" /p:"%(ENV_RDP_PASSWORD)s" /v:"%(ENV_RDP_HOST)s":"%(ENV_RDP_PORT)s" %(ENV_RDP_ARGUMENTS)s
 autorestart = true


### PR DESCRIPTION
Updated script to use `xfreerdp`, not `freerdp`.

Fixes #2.